### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 ## Disclaimer
 
-| :warning: | This project is no longer being maintained. Please use [contributte/latte](https://github.com/contributte/latte).
+| :warning: | This project is no longer being maintained. Please use [contributte/latte](https://github.com/contributte/latte).|
 |---|---|
 
-| Composer | [`contributte/latte`](https://packagist.org/packages/contributte/latte-email) |
+| Composer | [`contributte/latte-email`](https://packagist.org/packages/contributte/latte-email) |
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/contributte/latte-email) |
 | PHP | ![](https://badgen.net/packagist/php/contributte/latte-email) |
@@ -79,9 +79,9 @@ public function createTemplate()
 * texy
 
 
-### Development
+## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -90,4 +90,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
## Summary

This PR fixes several issues in the archived README to align it with the archive template:

- Fixed composer package name in table (was showing `contributte/latte` instead of `contributte/latte-email`)
- Fixed grammar: "was maintain" → "was maintained"
- Fixed grammar: "being used" → "using"
- Fixed "Development" heading level (was ### instead of ##)
- Minor formatting fixes to disclaimer table

The repository was already in archive style, but these corrections ensure consistency with the archive template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)